### PR TITLE
fix/destroy-waiter: Remove waiter from store on destroy

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -5,7 +5,6 @@ const initialState = {}
 
 const reducerMap = {
   // all the waiters
-  [t.RESET_ALL]: () => initialState,
   [t.CLEAR_ALL]: state => Object.values(state).reduce((acc, curr) => {
     // eslint-disable-next-line no-param-reassign
     acc[curr.name] = waiter(state[curr.name], { type: t.CLEAR })

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -37,10 +37,12 @@ const reducerMap = {
     ...state,
     [payload.name]: waiter(state[payload.name], { type: t.CLEAR, payload }),
   }),
-  [t.DESTROY]: (state, payload) => ({
-    ...state,
-    [payload.name]: waiter(state[payload.name], { type: t.RESET, payload }),
-  }),
+  [t.DESTROY]: (state, payload) => Object.keys(state).reduce((acc, curr) => {
+    if (curr === payload.name) {
+      return acc
+    }
+    return { ...acc, [curr]: state[curr] }
+  }, {}),
   [t.CANCEL_ALL]: state => state.map(w => waiter(w, { type: t.CANCEL })),
   [t.DESTROY_ALL]: () => initialState,
 }

--- a/src/waiter-reducer.js
+++ b/src/waiter-reducer.js
@@ -133,7 +133,6 @@ const reducerMap = {
     lastModified: null,
     attempts: 0,
   }),
-  [t.DESTROY]: () => waiterModel,
 }
 
 export default (state = waiterModel, action) => {


### PR DESCRIPTION
The docs say the destroy action should remove the waiter from the store, but I wasn't seeing that behavior. I've changed the destroy action to be in line.