### PR TITLE
imp/release-script: Add no-verify to push commands

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,8 +48,8 @@ function publish() {
   echo -e $DONE_MESSAGE
 
   echo -n "Pushing version bump and tags..."
-  git push origin "$BRANCH_NAME" --quiet
-  git push origin "$BRANCH_NAME" --tags --quiet
+  git push origin "$BRANCH_NAME" --quiet --no-verify
+  git push origin "$BRANCH_NAME" --tags --quiet --no-verify
   echo -e $DONE_MESSAGE
 }
 


### PR DESCRIPTION
The prepush hooks were running tests for the `git push` on the release branch. Since the tests are already run as apart of the `prepare` script prior to publish, running them two more times felt like overkill :)