### PR TITLE
fix/temp-call-waiter-return: Use old pattern for returning request in callWaiter

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -111,7 +111,7 @@ export function callWaiter(name, { requestCreator, params }) {
     dispatch(initRequest(name, { request }));
     const waiterId = getWaiter(getState(), name).id;
 
-    return request
+    request
       .then((data) =>
         dispatch(
           waiterResponseHandler(name, {
@@ -130,6 +130,8 @@ export function callWaiter(name, { requestCreator, params }) {
           })
         )
       );
+
+    return request;
   };
 }
 


### PR DESCRIPTION
Pt. 1 of the approach discussed in #37 

After this has been released, I will revert this and re-release to solidify the new return.